### PR TITLE
Ensure expected minimal node version as a readable error

### DIFF
--- a/packages/goat/src/cli.js
+++ b/packages/goat/src/cli.js
@@ -1,0 +1,58 @@
+const updateNotifier = require('update-notifier');
+const commander = require('commander');
+const Notifier = require('@the-goat/notifier');
+const CollectCommands = require('./methods/commands/CollectCommands');
+const setCommandWatch = require('./commands/watch');
+const setCommandModule = require('./commands/module');
+const setCommandProject = require('./commands/project');
+const pkg = require('../package.json');
+const getPackages = require('./packages/getPackages');
+
+const goat = new commander.Command();
+
+async function base() {
+    updateNotifier({ pkg }).notify();
+    goat
+        .version(pkg.version, '-v, -V, --version', 'output the current version')
+        .name('Goat')
+        .description('Goat');
+
+    goat
+        .option('-D, --debug', 'Debug Goat and modules');
+
+    let config;
+    try {
+        config = await require('./config/goatConfig')();
+    } catch (error) {
+        const setCommandInit = require('./commands/init');
+        goat.addCommand(setCommandInit());
+        if (process.argv.length === 2) {
+            Notifier.error(error.message);
+        }
+    }
+
+    if (config) {
+        const packages = await getPackages(config);
+        const moduleCommands = await CollectCommands(packages);
+        if (moduleCommands) {
+            moduleCommands.forEach((command) => {
+                goat.addCommand(command);
+            });
+            goat.addCommand(setCommandWatch(packages));
+        }
+    }
+
+    goat.addCommand(setCommandProject());
+    goat.addCommand(setCommandModule());
+    goat.allowUnknownOption(true);
+    goat.parse(process.argv);
+}
+
+module.exports = () => {
+    global.DEBUG = process.argv.includes('--debug') || process.argv.includes('-D');
+    if (global.DEBUG) {
+        const timeFunction = require('./methods/debug/timeFunction');
+        return timeFunction(base, 'goat');
+    }
+    return base();
+};

--- a/packages/goat/src/index.js
+++ b/packages/goat/src/index.js
@@ -1,58 +1,16 @@
-const updateNotifier = require('update-notifier');
-const commander = require('commander');
-const Notifier = require('@the-goat/notifier');
-const CollectCommands = require('./methods/commands/CollectCommands');
-const setCommandWatch = require('./commands/watch');
-const setCommandModule = require('./commands/module');
-const setCommandProject = require('./commands/project');
-const pkg = require('../package.json');
-const getPackages = require('./packages/getPackages');
+var pkg = require('../package.json');
+var semver = require('semver');
 
-const goat = new commander.Command();
-
-async function base() {
-  updateNotifier({ pkg }).notify();
-  goat
-    .version(pkg.version, '-v, -V, --version', 'output the current version')
-    .name('Goat')
-    .description('Goat');
-
-  goat
-    .option('-D, --debug', 'Debug Goat and modules');
-
-  let config;
-  try {
-    config = await require('./config/goatConfig')();
-  } catch (error) {
-    const setCommandInit = require('./commands/init');
-    goat.addCommand(setCommandInit());
-    if (process.argv.length === 2) {
-      Notifier.error(error.message);
-    }
+module.exports = function goat() {
+  if (!semver.satisfies(process.version, pkg.engines.node)) {
+    process.stderr.write([
+        'Invalid node version',
+        process.version,
+        'requires',
+        pkg.engines.node,
+        '\n'
+    ].join(' '));
+    process.exit(-1);
   }
-
-  if (config) {
-    const packages = await getPackages(config);
-    const moduleCommands = await CollectCommands(packages);
-    if (moduleCommands) {
-      moduleCommands.forEach((command) => {
-        goat.addCommand(command);
-      });
-      goat.addCommand(setCommandWatch(packages));
-    }
-  }
-
-  goat.addCommand(setCommandProject());
-  goat.addCommand(setCommandModule());
-  goat.allowUnknownOption(true);
-  goat.parse(process.argv);
-}
-
-module.exports = () => {
-  global.DEBUG = process.argv.includes('--debug') || process.argv.includes('-D');
-  if (global.DEBUG) {
-    const timeFunction = require('./methods/debug/timeFunction');
-    return timeFunction(base, 'goat');
-  }
-  return base();
+  return require('/cli.js');
 };


### PR DESCRIPTION
Ensure expected minimal node version (from package.json) as a readable error

fixes #30

## node v10

Instead of 
````shell
(node:1625963) UnhandledPromiseRejectionWarning: TypeError: modules.flatMap is not a function
    at getModules (/home/X/.config/yarn/global/node_modules/@geit/goat/src/packages/getPackages.js:10:18)
    at base (/home/X/.config/yarn/global/node_modules/@geit/goat/src/index.js:36:28)
(node:1625963) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:1625963) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
````

we now get
````shell
Invalid node version v10.23.2 , requires >=11.00
````

## node v8

Instead of 

````shell
/home/X/.config/yarn/global/node_modules/@geit/goat/node_modules/update-notifier/index.js:58
			} catch {
			        ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:617:28)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (/home/X/.config/yarn/global/node_modules/@geit/goat/src/index.js:1:86)
````

we now get
````shell
Invalid node version v8.17.0 requires >=11.00 
````
